### PR TITLE
Add simple test to image before uploading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "RUST_TOOLCHAIN=${{ github.event.inputs.rust_toolchain || 'nightly' }}"
 
+      - name: Test built image
+        run: |
+          docker run \
+            --mount type=bind,source="$(pwd)"/test.sh,target=/test.sh,readonly \
+            ${{ steps.build.outputs.imageid }} \
+            /test.sh
+
       - name: Push image to ghcr
         run: |
           docker push --all-tags ${{ env.IMAGE_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
         required: true
         default: "nightly"
 
+env:
+  IMAGE_NAME: ghcr.io/vita-rust/vitasdk-rs
+
 jobs:
   build:
     name: Build
@@ -32,15 +35,19 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/vita-rust/vitasdk-rs
+          images: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
 
-      - name: Build and push Docker image to ghcr
+      - name: Build Docker image
+        id: build
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "RUST_TOOLCHAIN=${{ github.event.inputs.rust_toolchain || 'nightly' }}"
+
+      - name: Push image to ghcr
+        run: |
+          docker push --all-tags ${{ env.IMAGE_NAME }}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+cd /tmp
+
+cat > "test.rs" << EOF
+fn main() {}
+EOF
+
+cargo +nightly build --target armv7-sony-vita-newlibeabihf -Zbuild-std -Zscript --manifest-path test.rs


### PR DESCRIPTION
- Pushing only (with the image name changed to my fork): [run](https://github.com/pheki/vita-rust-docker/actions/runs/7536153863), [diff](https://github.com/vita-rust/docker/compare/main..1cad18e31de1082ce5ff0442e53d35883ea16927)
- Whole run: https://github.com/pheki/vita-rust-docker/actions/runs/7536344986

This would help us:
- Not push images with broken compiler / `std` versions
- Realize sooner when the compiler / `std` breaks (although for this one we also probably want to build all examples)